### PR TITLE
Fix missing #include <vector>

### DIFF
--- a/arduino/smartcar_mqtt/smartcar_mqtt.ino
+++ b/arduino/smartcar_mqtt/smartcar_mqtt.ino
@@ -1,3 +1,4 @@
+#include <vector>
 #include <Smartcar.h>
 #include <MQTT.h>
 #ifdef __SMCE__


### PR DESCRIPTION
Worked on our machines because libstdc++ leaks every header everywhere, but M$ STL doesn't leak that one, so we finally caught that bug.