### PR TITLE
Replacing jcenter with mavenCentral

### DIFF
--- a/android/SmartcarMqttController/build.gradle
+++ b/android/SmartcarMqttController/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
 
         repositories {
             maven {
@@ -22,7 +22,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
Changes jcenter to mavenCentral due to jcenter not being updated anymore with mavenCentral being the suggested replacement.